### PR TITLE
Fix bug when pressing key repeatedly after field is full

### DIFF
--- a/src/mask.js
+++ b/src/mask.js
@@ -338,7 +338,6 @@ angular.module('ui.mask', [])
                                         valMasked,
                                         valUnmasked = unmaskValue(val),
                                         valUnmaskedOld = oldValueUnmasked,
-                                        valAltered = false,
                                         caretPos = getCaretPosition(this) || 0,
                                         caretPosOld = oldCaretPosition || 0,
                                         caretPosDelta = caretPos - caretPosOld,
@@ -384,7 +383,6 @@ angular.module('ui.mask', [])
                                     var charIndex = maskCaretMap.indexOf(caretPos);
                                     // Strip out non-mask character that user would have deleted if mask hadn't been in the way.
                                     valUnmasked = valUnmasked.substring(0, charIndex) + valUnmasked.substring(charIndex + 1);
-                                    valAltered = true;
                                 }
 
                                 // Update values
@@ -393,12 +391,7 @@ angular.module('ui.mask', [])
                                 oldValue = valMasked;
                                 oldValueUnmasked = valUnmasked;
                                 iElement.val(valMasked);
-                                if (valAltered) {
-                                    // We've altered the raw value after it's been $digest'ed, we need to $apply the new value.
-                                    scope.$apply(function() {
-                                        controller.$setViewValue(valUnmasked);
-                                    });
-                                }
+                                controller.$setViewValue(valUnmasked);
 
                                 // Caret Repositioning
                                 // ===================

--- a/test/maskSpec.js
+++ b/test/maskSpec.js
@@ -85,6 +85,16 @@ describe("uiMask", function () {
       expect(scope.test.input.$viewValue).toBe("(a) _ _");
     });
 
+    it("should maintain $viewValue consistent with input value", function() {
+      var form  = compileElement(formHtml);
+      var input = form.find("input");
+      scope.$apply("x = ''");
+      scope.$apply("mask = '99 9'");
+      input.val("3333").triggerHandler("input");
+      input.val("3333").triggerHandler("input"); // It used to has a bug when pressing a key repeatedly
+      expect(scope.test.input.$viewValue).toBe("33 3");
+    });
+
     it("should parse unmasked value to model", function() {
       var form  = compileElement(formHtml);
       var input = form.find("input");
@@ -249,7 +259,6 @@ describe("uiMask", function () {
       scope.$apply("myDate = ''");
       expect(input.attr("placeholder")).toBe("DD/MM/YYYY HH:mm");
     });
-
   });
 
   describe("configuration", function () {


### PR DESCRIPTION
Fix #10.

I think `scope.$apply` was being used caused of issue #1.
After fixing it, there is no need to wait next digest to change viewValue.