### PR TITLE
fixed caret position when pasting text

### DIFF
--- a/src/mask.js
+++ b/src/mask.js
@@ -172,6 +172,7 @@ angular.module('ui.mask', [])
                                 iElement.bind('blur', blurHandler);
                                 iElement.bind('mousedown mouseup', mouseDownUpHandler);
                                 iElement.bind('input keyup click focus', eventHandler);
+                                iElement.bind('paste', onPasteHandler);
                                 eventsBound = true;
                             }
 
@@ -186,6 +187,7 @@ angular.module('ui.mask', [])
                                 iElement.unbind('keyup', eventHandler);
                                 iElement.unbind('click', eventHandler);
                                 iElement.unbind('focus', eventHandler);
+                                iElement.unbind('paste', onPasteHandler);
                                 eventsBound = false;
                             }
 
@@ -322,6 +324,10 @@ angular.module('ui.mask', [])
                                 /*jshint validthis: true */
                                 oldSelectionLength = getSelectionLength(this);
                                 iElement.unbind('mouseout', mouseoutHandler);
+                            }
+
+                            function onPasteHandler(e) {
+                                setCaretPosition(this, iElement.val().length);
                             }
 
                             function eventHandler(e) {


### PR DESCRIPTION
I had the following mask: (999) 999-9999

When I pasted a phone number like 5033245467, the caret was positioned at 5033245|467, because of the three mask characters ( ) -.  To overcome this, I hoked into the paste event (which is compatible across browsers) and set the caret position to the unmasket text length.