### PR TITLE
Allow fine grained event control

### DIFF
--- a/src/mask.js
+++ b/src/mask.js
@@ -179,7 +179,7 @@ angular.module('ui.mask', [])
                                 }
                                 iElement.bind('blur', blurHandler);
                                 iElement.bind('mousedown mouseup', mouseDownUpHandler);
-                                iElement.bind(listOptions.eventsToHandle.join(' '), eventHandler);
+                                iElement.bind(linkOptions.eventsToHandle.join(' '), eventHandler);
                                 iElement.bind('paste', onPasteHandler);
                                 eventsBound = true;
                             }

--- a/src/mask.js
+++ b/src/mask.js
@@ -8,7 +8,8 @@ angular.module('ui.mask', [])
                 'A': /[a-zA-Z]/,
                 '*': /[a-zA-Z0-9]/
             },
-            clearOnBlur: true
+            clearOnBlur: true,
+            eventsToHandle: ['input', 'keyup', 'click', 'focus']
         })
         .directive('uiMask', ['uiMaskConfig', '$parse', function(maskConfig, $parse) {
                 function isFocused (elem) {
@@ -178,7 +179,7 @@ angular.module('ui.mask', [])
                                 }
                                 iElement.bind('blur', blurHandler);
                                 iElement.bind('mousedown mouseup', mouseDownUpHandler);
-                                iElement.bind('input keyup click focus', eventHandler);
+                                iElement.bind(listOptions.eventsToHandle.join(' '), eventHandler);
                                 iElement.bind('paste', onPasteHandler);
                                 eventsBound = true;
                             }


### PR DESCRIPTION
This change enables the ability to remove/add events that should be
handled by the eventHandler function. The purpose for this change is to
fix the cursor issue that occurs with Android browsers.

If you remove the 'input' event from the eventsToHandle then the ui-mask
directive works properly for Android browsers. However, you can't just
remove it permanently as that causes other UX issues on non-Android
browsers.

Hopefully this can be used for people to fix issues related to #21.

Code snippet on how it can be configured globally (please let me know if there is a better way)

```javascript
   app.run(['uiMaskConfig',  function (uiMaskConfig) {
        var isAndroid = /(android)/i.test(navigator.userAgent);
        if (isAndroid) {
            var index = uiMaskConfig.eventsToHandle.indexOf('input');
            uiMaskConfig.eventsToHandle.splice(index, 1);
        }
    }]); 
```