### PR TITLE
Fix for #35 model-view-value handling

### DIFF
--- a/src/mask.js
+++ b/src/mask.js
@@ -11,7 +11,7 @@ angular.module('ui.mask', [])
             clearOnBlur: true,
             eventsToHandle: ['input', 'keyup', 'click', 'focus']
         })
-        .directive('uiMask', ['uiMaskConfig', '$parse', function(maskConfig, $parse) {
+        .directive('uiMask', ['uiMaskConfig', function(maskConfig) {
                 function isFocused (elem) {
                   return elem === document.activeElement && (!document.hasFocus || document.hasFocus()) && !!(elem.type || elem.href || ~elem.tabIndex);
                 }
@@ -60,6 +60,12 @@ angular.module('ui.mask', [])
                                     iElement.val(maskValue(unmaskValue(iElement.val())));
                                 }
                             }
+                            var modelViewValue = false;
+                            iAttrs.$observe('modelViewValue', function(val) {
+                                if (val === 'true') {
+                                    modelViewValue = true;
+                                }
+                            });
 
                             function formatter(fromModelValue) {
                                 if (!maskProcessed) {
@@ -86,7 +92,11 @@ angular.module('ui.mask', [])
                                 if (value === '' && iAttrs.required) {
                                     controller.$setValidity('required', !controller.$error.required);
                                 }
-                                return isValid ? value : undefined;
+                                if (isValid) {
+                                    return modelViewValue ? controller.$viewValue : value;
+                                } else {
+                                    return undefined;
+                                }
                             }
 
                             var linkOptions = {};
@@ -119,18 +129,6 @@ angular.module('ui.mask', [])
                             else {
                                 iAttrs.$observe('placeholder', initPlaceholder);
                             }
-                            var modelViewValue = false;
-                            iAttrs.$observe('modelViewValue', function(val) {
-                                if (val === 'true') {
-                                    modelViewValue = true;
-                                }
-                            });
-                            scope.$watch(iAttrs.ngModel, function(val) {
-                                if (modelViewValue && val) {
-                                    var model = $parse(iAttrs.ngModel);
-                                    model.assign(scope, controller.$viewValue);
-                                }
-                            });
                             controller.$formatters.push(formatter);
                             controller.$parsers.push(parser);
 

--- a/test/maskSpec.js
+++ b/test/maskSpec.js
@@ -78,7 +78,7 @@ describe("uiMask", function () {
     });
 
   });
-  describe("other directives", function() {
+  describe("with other directives", function() {
     beforeEach(function () {
       compileElement("<form name='test'><input to-upper name='input' ng-model='x' ui-mask='{{mask}}'></form>");
     });
@@ -90,8 +90,21 @@ describe("uiMask", function () {
       scope.$apply("mask = '(A)AA'");
       expect(scope.test.input.$viewValue).toBe("(A)BC");
     });
-
-
+    describe("with model-view-value", function() {
+      var input = undefined;
+      beforeEach(function () {
+        input = compileElement("<form name='test'><input to-upper name='input' ng-model='x' model-view-value='true' ui-mask='{{mask}}'></form>");
+        input = input.find('input')
+      });
+      it("should play nicely", function() {
+        scope.$apply("x = '(a) b 1'");
+        scope.$apply("mask = '(A) * 9'");
+        expect(scope.test.input.$viewValue).toBe("(A) B 1");
+        input.val("(A) C 2").triggerHandler("input").triggerHandler("change");
+        scope.$apply();
+        expect(scope.x).toBe("(a) c 2");
+      });
+    });
   });
 
   describe("user input", function () {
@@ -191,6 +204,21 @@ describe("uiMask", function () {
     });
   });
 
+  describe("with model-view-value", function() {
+    var input = undefined;
+    beforeEach(function () {
+      input = compileElement("<form name='test'><input name='input' ng-model='x' model-view-value='true' ui-mask='{{mask}}'></form>");
+      input = input.find('input')
+    });
+    it("should set the mask in the model", function() {
+      scope.$apply("x = '(a) b 1'");
+      scope.$apply("mask = '(A) * 9'");
+      expect(scope.test.input.$viewValue).toBe("(a) b 1");
+      input.val("(a) c 2").triggerHandler("input").triggerHandler("change");
+      scope.$apply();
+      expect(scope.x).toBe("(a) c 2");
+    });
+  });
   describe("changes from the model", function () {
     it("should set the correct ngModelController.$viewValue", function() {
       compileElement(formHtml);

--- a/test/maskSpec.js
+++ b/test/maskSpec.js
@@ -96,7 +96,7 @@ describe("uiMask", function () {
         input = compileElement("<form name='test'><input to-upper name='input' ng-model='x' model-view-value='true' ui-mask='{{mask}}'></form>");
         input = input.find('input')
       });
-      it("should play nicely", function() {
+      it("should set the model value to the masked view value parsed by other directive", function() {
         scope.$apply("x = '(a) b 1'");
         scope.$apply("mask = '(A) * 9'");
         expect(scope.test.input.$viewValue).toBe("(A) B 1");


### PR DESCRIPTION
This PR fixes the handling of model-view-value=true. When ui-mask is used with another directive of higher priority and model-view-value is true, the code is setting $modelValue directly so the other directives $parsers is not being called.