### PR TITLE
Run tests through sauceLabs in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,19 @@
 language: node_js
 node_js:
-- '0.12'
+- '0.11'
 git:
   depth: 10
 before_install:
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
 - npm install -qg bower gulp-cli
 - npm install -q
 - bower install --force
 - bower install --force
-script: gulp
+script: gulp ci
+sudo: false
+env:
+  global:
+    - SAUCE_USERNAME=angular-ui-mask
+    - SAUCE_ACCESS_KEY=b4b4d64e-4188-4cae-a91c-29214a389c8a
 deploy:
   provider: npm
   email: adrien.crivelli@gmail.com

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,9 +13,12 @@ var plumber = require('gulp-plumber');//To prevent pipe breaking caused by error
 var git = require('gulp-git');
 var bump = require('gulp-bump');
 var runSequence = require('run-sequence');
+var geSaLaKaCuLa = require('gesalakacula');
+var reKaLa = geSaLaKaCuLa.recursiveKarmaLauncher;
 var versionAfterBump;
 
 gulp.task('default', ['build', 'test']);
+gulp.task('ci', ['karma-sauce']);
 gulp.task('build', ['scripts']);
 gulp.task('test', ['build', 'karma']);
 
@@ -74,6 +77,26 @@ gulp.task('karma', ['build'], function() {
 gulp.task('karma-watch', ['build'], function() {
     var server = new Server({configFile: __dirname + '/karma.conf.js', singleRun: false});
     server.start();
+});
+
+gulp.task('karma-sauce', ['build'], function() {
+  var customLaunchers = geSaLaKaCuLa({
+    // TODO: add windows testing in once
+    // #5 is fixed https://github.com/angular-ui/ui-mask/issues/5
+    // 'Windows 7': {
+    //   'internet explorer': '9..11',
+    // },
+    'OS X 10.10': {
+      'chrome': '43..44',
+      'firefox': '39..40',
+      'safari': '8'
+    }
+  });
+
+  reKaLa({
+    karma: Server,
+    customLaunchers: customLaunchers
+  }, process.exit);
 });
 
 var handleError = function(err) {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -64,4 +64,17 @@ module.exports = function(config) {
     // if true, it capture browsers, run tests and exit
     singleRun: false
   });
+
+  // Sauce Specific configuration for CI
+  if (process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY) {
+    config.reporters.push('saucelabs');
+
+    config.set({
+      sauceLabs: {
+        testName: 'UI Mask CI'
+      },
+      captureTimeout:  120000,
+      singleRun: true
+    });
+  }
 };

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "devDependencies": {
     "del": "~1.2.0",
     "event-stream": "~3.3.1",
+    "gesalakacula": "^1.4.0",
     "gulp": "~3.9.0",
     "gulp-bump": "^0.3.1",
     "gulp-concat": "~2.6.0",
@@ -27,6 +28,7 @@
     "karma-jasmine": "~0.3",
     "karma-ng-html2js-preprocessor": "^0.1.0",
     "karma-phantomjs-launcher": "~0.2.1",
+    "karma-sauce-launcher": "^0.2.14",
     "phantomjs": "^1.9.18",
     "run-sequence": "^1.1.2"
   },


### PR DESCRIPTION
This runs unit tests on multiple browsers via SauceLabs in CI.

A quick breakdown of the changes:

- Use [gesalakacula](https://github.com/douglasduteil/gesalakacula) for easier browser configuration and to avoid timeouts going over sauce's maximum concurrency limit
- Added additional config settings in `karma.conf.js` if sauce credentials exist on env
- I bumped the node version on Travis down to `0.11` because SauceConnect seemed to have issues `0.12`. This doesn't feel super wrong since we just need node to start the tests, so it shouldn't effect the results of the tests. I'll try to bump this up to a more recent version after some additional investigation.