### PR TITLE
limit optional mask to a single character

### DIFF
--- a/src/mask.js
+++ b/src/mask.js
@@ -302,6 +302,8 @@ angular.module('ui.mask', [])
                                             if (!isOptional) {
                                                 minRequiredLength++;
                                             }
+
+                                            isOptional = false;
                                         }
                                         else if (chr === '?') {
                                             isOptional = true;

--- a/test/maskSpec.js
+++ b/test/maskSpec.js
@@ -289,6 +289,16 @@ describe("uiMask", function () {
       input.triggerHandler("blur");
       expect(input.val()).toBe("992");
     });
+
+    it("should limit optional mask to a single character", function() {
+      var form  = compileElement(formHtml);
+      var input = form.find("input");
+      scope.$apply("x = ''");
+      scope.$apply("mask = '9?99'");
+      input.val("1").triggerHandler("input");
+      input.triggerHandler("change"); // Because IE8 and below are terrible
+      expect(scope.x).toBeUndefined();
+    });
   });
 
   describe("placeholders", function () {


### PR DESCRIPTION
In the current implementation, the optional character makes all subsequent mask characters optional.  For example, a mask of `9?99` with an input of `1` is valid.  It seems like this should be invalid.

After this PR, a mask of `9?99` with an input of `1` would be invalid.  Inputs of `11` and `111` would be valid.  This is consistent with the extension example on the demo page.