### PR TITLE
Fix bug in controller.$isEmpty function

### DIFF
--- a/src/mask.js
+++ b/src/mask.js
@@ -37,7 +37,7 @@ angular.module('ui.mask', [])
 
                             var originalIsEmpty = controller.$isEmpty;
 	                        controller.$isEmpty = function(value) {
-		                        if (maskPatterns) {
+		                        if (maskProcessed) {
 			                        return originalIsEmpty(unmaskValue(value || ''));
 		                        } else {
 			                        return originalIsEmpty(value);

--- a/test/maskSpec.js
+++ b/test/maskSpec.js
@@ -233,6 +233,14 @@ describe("uiMask", function () {
       expect(scope.x).toBe("ab1");
       expect(input.data("$ngModelController").$error.required).toBeUndefined();
     });
+
+    it("should set the model value properly when control is required and the mask is undefined", function() {
+      var input = compileElement('<input ng-required="true" ui-mask="{{mask}}" ng-model="x" />');
+      scope.$apply("x = ''");
+      expect(scope.mask).toBeUndefined();
+      input.val("12345").triggerHandler("change");
+      expect(scope.x).toBe("12345");
+    });
   });
 
   describe("verify change is called", function () {


### PR DESCRIPTION
The conditional check in the $isEmpty function was not properly
detecting if a mask had been processed successfully.

Fix for #84 based on the discussion on PR #86 

No need for PR #86 if this gets merged.