### PR TITLE
Fix nested in ng-if issue

### DIFF
--- a/src/mask.js
+++ b/src/mask.js
@@ -65,7 +65,11 @@ angular.module('ui.mask', [])
                                 maskPlaceholder = placeholderAttr;
 
                                 // If the mask is processed, then we need to update the value
-                                if (maskProcessed) {
+                                // but don't set the value if there is nothing entered into the element
+                                // and there is a placeholder attribute on the element because that
+                                // will only set the value as the blank maskPlaceholder
+                                // and override the placeholder on the element
+                                if (maskProcessed && !(iElement.val().length === 0 && angular.isDefined(iAttrs.placeholder))) {
                                     iElement.val(maskValue(unmaskValue(iElement.val())));
                                 }
                             }

--- a/test/maskSpec.js
+++ b/test/maskSpec.js
@@ -89,6 +89,7 @@ describe("uiMask", function () {
     });
 
   });
+
   describe("with other directives", function() {
     beforeEach(function () {
       compileElement("<form name='test'><input to-upper name='input' ng-model='x' ui-mask='{{mask}}'></form>");
@@ -115,6 +116,15 @@ describe("uiMask", function () {
         scope.$apply();
         expect(scope.x).toBe("(a) c 2");
       });
+    });
+
+    describe("nested inside another directive", function() {
+        it("should have the correct placeholder value inside ng-if", function() {
+            var input = compileElement('<div><div ng-if="showMe"><input type="text" ng-model="x" ui-mask="99/99/9999" ui-mask-placeholder="__/__/____" placeholder="date" /></div></div>');
+            scope.$apply("showMe = true");
+            input = input.find('input');
+            expect(input.val()).toBe("");
+        })
     });
   });
 


### PR DESCRIPTION
Added a check to the initPlaceholder function to ensure it only updates
the element value if there is a value on the element or if there is not
a placeholder attribute on the element.

If the element value is blank and the element has a placeholder
attribute, then the element's value does not get updated.

Fixes #58 