### PR TITLE
Add protractor testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '0.11'
+- 'node'
 git:
   depth: 10
 before_install:
@@ -22,3 +22,6 @@ deploy:
   on:
     tags: true
     repo: angular-ui/ui-mask
+
+addons:
+    sauce_connect: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,3 @@ deploy:
   on:
     tags: true
     repo: angular-ui/ui-mask
-
-addons:
-    sauce_connect: true

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -53,7 +53,7 @@ module.exports = function(config) {
     // - Safari (only Mac)
     // - PhantomJS
     // - IE (only Windows)
-    browsers: ['PhantomJS'],
+    browsers: ['Firefox'],
 
 
     // If browser does not capture in given timeout [ms], kill it

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -53,7 +53,7 @@ module.exports = function(config) {
     // - Safari (only Mac)
     // - PhantomJS
     // - IE (only Windows)
-    browsers: ['Firefox'],
+    browsers: ['PhantomJS'],
 
 
     // If browser does not capture in given timeout [ms], kill it
@@ -71,7 +71,9 @@ module.exports = function(config) {
 
     config.set({
       sauceLabs: {
-        testName: 'UI Mask CI'
+        testName: 'UI Mask CI',
+        tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER,
+        startConnect: false
       },
       captureTimeout:  120000,
       singleRun: true

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "karma-firefox-launcher": "~0.1",
     "karma-jasmine": "~0.3",
     "karma-ng-html2js-preprocessor": "^0.1.0",
-    "karma-phantomjs-launcher": "~0.2.1",
     "karma-sauce-launcher": "^0.2.14",
     "phantomjs": "^1.9.18",
     "protractor": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "event-stream": "~3.3.1",
     "gesalakacula": "^1.4.0",
     "gulp": "~3.9.0",
+    "gulp-angular-protractor": "0.0.6",
     "gulp-bump": "^0.3.1",
     "gulp-concat": "~2.6.0",
+    "gulp-connect": "^2.3.1",
     "gulp-footer": "~1.0.5",
     "gulp-git": "^1.4.0",
     "gulp-header": "~1.2.2",
@@ -30,6 +32,7 @@
     "karma-phantomjs-launcher": "~0.2.1",
     "karma-sauce-launcher": "^0.2.14",
     "phantomjs": "^1.9.18",
+    "protractor": "^3.0.0",
     "run-sequence": "^1.1.2"
   },
   "scripts": {},

--- a/protractor.config.js
+++ b/protractor.config.js
@@ -1,0 +1,5 @@
+exports.config = {
+    seleniumAddress: 'http://localhost:4444/wd/hub',
+    specs: ['test/maskSpec.protractor.js'],
+    baseUrl: 'http://localhost:8000'
+};

--- a/protractor.travis.config.js
+++ b/protractor.travis.config.js
@@ -1,0 +1,14 @@
+exports.config = {
+    sauceUser: process.env.SAUCE_USERNAME,
+    sauceKey: process.env.SAUCE_ACCESS_KEY,
+
+    capabilities: {
+      'browserName': 'chrome',
+      'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
+      'build': process.env.TRAVIS_BUILD_NUMBER,
+      'name': 'ui-mask Protractor Tests'
+    },
+
+    specs: ['test/maskSpec.protractor.js'],
+    baseUrl: 'http://localhost:8000'
+};

--- a/test/maskSpec.protractor.js
+++ b/test/maskSpec.protractor.js
@@ -1,0 +1,24 @@
+describe('user input', function() {
+  it('should remove characters properly when backspacing', function() {
+    browser.get('demo/index.html');
+
+    var definitionElement = element(by.id('definition'));
+    definitionElement.sendKeys('QT****');
+
+    var maskedElement = element(by.id('masked'));
+    maskedElement.sendKeys('1234');
+    expect(maskedElement.getAttribute('value')).toBe('QT1234');
+    maskedElement.sendKeys(protractor.Key.BACK_SPACE);
+    expect(maskedElement.getAttribute('value')).toBe('QT123_');
+
+    definitionElement.clear();
+    definitionElement.sendKeys('QT**BC**');
+    maskedElement.sendKeys('1234');
+    expect(maskedElement.getAttribute('value')).toBe('QT12BC34');
+    maskedElement.sendKeys(protractor.Key.BACK_SPACE);
+    expect(maskedElement.getAttribute('value')).toBe('QT12BC3_');
+    maskedElement.sendKeys(protractor.Key.BACK_SPACE);
+    maskedElement.sendKeys(protractor.Key.BACK_SPACE);
+    expect(maskedElement.getAttribute('value')).toBe('QT1_BC__');
+  });
+});


### PR DESCRIPTION
Setup gulp tasks to run protractor tests locally and during travis
builds using sauce labs for the travis build

Update to newest node version

Needed to upgrade the version of node being installed during the travis
build so that it would work properly with protractor

Update karma conf

Added the travis tunnel identifier for sauce labs and start connect as
false to utilize the already started sauce connect from the protractor
tests

Added protractor testing to assist with #98 

This also should allow for more robust testing in the future