### PR TITLE
Prevent call to $setViewValue if value not changed

### DIFF
--- a/src/mask.js
+++ b/src/mask.js
@@ -497,7 +497,10 @@ angular.module('ui.mask', [])
                                     var charIndex = maskCaretMap.indexOf(caretPos);
                                     // Strip out non-mask character that user would have deleted if mask hadn't been in the way.
                                     valUnmasked = valUnmasked.substring(0, charIndex) + valUnmasked.substring(charIndex + 1);
-                                    valAltered = true;
+                                    
+                                    // If value has not changed, don't want to call $setViewValue, may be caused by IE raising input event due to placeholder
+                                    if (valUnmasked !== valUnmaskedOld)
+                                    	valAltered = true;
                                 }
 
                                 // Update values


### PR DESCRIPTION
In IE11, even with newer versions of angular, placeholder can still cause an input event to be raised in some scenarios, which gets registered as an attempt to delete when no value has been entered yet, causing the form to be dirty immediately. (relates to issue #29)