### PR TITLE
Show placeholder text properly when clearOnBlur: false

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ angular.module('myApp', [uiMask, ...]);
 ### Customizing
 You can customize several behaviors of ui-mask by taking advantage of the `ui-options` object. Declare `ui-options` as an additional attribute on the same element where you declare `ui-mask`.
 
-Inside of `ui-options`, you can customize these three properties:
+Inside of `ui-options`, you can customize these four properties:
 
 * `maskDefinitions` - default: `{
                 '9': /\d/,
@@ -63,9 +63,12 @@ Inside of `ui-options`, you can customize these three properties:
                 '*': /[a-zA-Z0-9]/
             }`,
 * `clearOnBlur` - default: `true`,
+* `clearOnBlurPlaceholder` - default: `false`,
 * `eventsToHandle` - default: `['input', 'keyup', 'click', 'focus']`
 
 When customizing `eventsToHandle` or `clearOnBlur`, the value you supply will replace the default. To customize `eventsToHandle`, be sure to replace the entire array.
+
+When setting `clearOnBlurPlaceholder` to `true`, it will show the placeholder text instead of the empty mask. It requires the `ui-mask-placeholder` attribute to be set on the input to display properly.
 
 Whereas, `maskDefinitions` is an object, so any custom object you supply will be merged together with the defaults using `angular.extend()`. This allows you to override the defaults selectively, if you wish.
 

--- a/src/mask.js
+++ b/src/mask.js
@@ -9,6 +9,7 @@ angular.module('ui.mask', [])
                 '*': /[a-zA-Z0-9]/
             },
             clearOnBlur: true,
+            clearOnBlurPlaceholder: false,
             eventsToHandle: ['input', 'keyup', 'click', 'focus']
         })
         .directive('uiMask', ['uiMaskConfig', function(maskConfig) {
@@ -347,7 +348,7 @@ angular.module('ui.mask', [])
 
                             var prevValue = iElement.val();
                             function blurHandler() {
-                                if (linkOptions.clearOnBlur) {
+                                if (linkOptions.clearOnBlur || ((linkOptions.clearOnBlurPlaceholder) && (value.length === 0) && iAttrs.placeholder)) {
                                     oldCaretPosition = 0;
                                     oldSelectionLength = 0;
                                     if (!isValid || value.length === 0) {
@@ -497,7 +498,7 @@ angular.module('ui.mask', [])
                                     var charIndex = maskCaretMap.indexOf(caretPos);
                                     // Strip out non-mask character that user would have deleted if mask hadn't been in the way.
                                     valUnmasked = valUnmasked.substring(0, charIndex) + valUnmasked.substring(charIndex + 1);
-                                    
+
                                     // If value has not changed, don't want to call $setViewValue, may be caused by IE raising input event due to placeholder
                                     if (valUnmasked !== valUnmaskedOld)
                                     	valAltered = true;

--- a/test/maskSpec.js
+++ b/test/maskSpec.js
@@ -611,6 +611,45 @@ describe("uiMask", function () {
       input.triggerHandler("blur");
       expect(input.val()).toBe("");
     });
+
+    var inputHtmlClearOnBlurPlaceholder = "<input name='input' ng-model='x' ui-mask='{{mask}}' ui-options=\"input.options\" ui-mask-placeholder placeholder=\"PLACEHOLDER\">";
+
+    it("should not show placeholder when value is invalid if clearOnBlurPlaceholder is false", function() {
+      scope.input = {
+        options: {
+          clearOnBlur: false,
+          clearOnBlurPlaceholder: false
+        }
+      };
+
+      var input = compileElement(inputHtmlClearOnBlurPlaceholder);
+
+      scope.$apply("x = ''");
+      scope.$apply("mask = '(9) * A'");
+
+      input.val("").triggerHandler("input");
+      input.triggerHandler("blur");
+      expect(input.val()).toBe("(_) _ _");
+    });
+
+    it("should show placeholder when value is invalid if clearOnBlurPlaceholder is true", function() {
+      scope.input = {
+        options: {
+          clearOnBlur: false,
+          clearOnBlurPlaceholder: true
+        }
+      };
+
+      var input = compileElement(inputHtmlClearOnBlurPlaceholder);
+
+      scope.$apply("x = ''");
+      scope.$apply("mask = '(9) * A'");
+
+      input.val("").triggerHandler("input");
+      input.triggerHandler("blur");
+      expect(input.val()).toBe("");
+      expect(input.attr("placeholder")).toBe("PLACEHOLDER");
+    });
   });
 
 });


### PR DESCRIPTION
Added clearOnBlurPlaceholder option to assist with #105

Previous behavior: When clearOnBlur is set to false, an empty input displays the empty mask instead of the placeholder, even when using the ui-mask-placeholder attribute.

New behavior: When clearOnBlur is set to false, and clearOnBlurPlaceholder defaults to false, the previous bahavior is kept. If clearOnBlurPlaceholder is set to true, an empty input displays the placeholder text instead of the empty mask.