### PR TITLE
Fix bug found in #103

### DIFF
--- a/test/maskSpec.js
+++ b/test/maskSpec.js
@@ -254,6 +254,22 @@ describe("uiMask", function () {
         expect(input.val()).toBe("QT____");
         expect(scope.x).toBe('');
     });
+
+    it("should set model value properly when the value contains the same character as a static mask character", function() {
+        var input = compileElement(inputHtml);
+        scope.$apply("mask = '19'");
+        input.triggerHandler("input");
+        expect(input.val()).toBe("1_");
+        input.val("11").triggerHandler("change");
+        expect(scope.x).toBe("1");
+
+        scope.$apply("mask = '9991999'");
+        scope.$apply("x = ''");
+        input.triggerHandler("input");
+        expect(input.val()).toBe("___1___");
+        input.val("1231456").triggerHandler("change");
+        expect(scope.x).toBe("123456");
+    });
   });
 
   describe("verify change is called", function () {


### PR DESCRIPTION
Refactored the unmaskValue function to handle a much wider range of
cases. Changed the removal of static mask components to be smarter so
that it hopefully removes the actual static mask component and not a
user inputted value

Modified the $setViewValue call in eventHandler so that it is called
with the masked value and not the unmasked value as the view value
should be the masked value not the unmasked value

Fixes #103 