### PR TITLE
Fix bug caused by multiple identical mask components

### DIFF
--- a/src/mask.js
+++ b/src/mask.js
@@ -320,10 +320,15 @@ angular.module('ui.mask', [])
                                     return s !== '';
                                 });
 
+                                // need a string search offset in cases where the mask contains multiple identical components
+                                // I.E. a mask of 99.99.99-999.99
+                                var offset = 0;
                                 return components.map(function(c) {
+                                    var componentPosition = maskPlaceholderCopy.indexOf(c, offset);
+                                    offset = componentPosition + 1;
                                     return {
                                         value: c,
-                                        position: maskPlaceholderCopy.indexOf(c)
+                                        position: componentPosition
                                     };
                                 });
                             }

--- a/test/maskSpec.js
+++ b/test/maskSpec.js
@@ -270,6 +270,13 @@ describe("uiMask", function () {
         input.val("1231456").triggerHandler("change");
         expect(scope.x).toBe("123456");
     });
+
+    it("should mask the input properly with multiple identical mask components", function() {
+        var input = compileElement(inputHtml);
+        scope.$apply("mask = '99.99.99-999.99'");
+        input.val("811").triggerHandler("input");
+        expect(input.val()).toBe("81.1_.__-___.__");
+    });
   });
 
   describe("verify change is called", function () {


### PR DESCRIPTION
Added a search offset in the getMaskComponents function so that if the
mask contains multiple identical mask components it will get the proper
string position of each component in the mask.

Fix for #108 caused by #107 