### PR TITLE
Fix IE 9,10,11 tab issue

### DIFF
--- a/src/mask.js
+++ b/src/mask.js
@@ -502,7 +502,7 @@ angular.module('ui.mask', [])
                                 oldSelectionLength = getSelectionLength(this);
 
                                 // These events don't require any action
-                                if (isSelection || (isSelected && (eventType === 'click' || eventType === 'keyup'))) {
+                                if (isSelection || (isSelected && (eventType === 'click' || eventType === 'keyup' || eventType === 'focus'))) {
                                     return;
                                 }
 


### PR DESCRIPTION
Ignores the 'focus' event in eventHandler is there is a selection.

This should fix the IE 9,10,11 tab issue where the input value is not
selected when tabbing into the field

#111