### PR TITLE
Fix issue where $invalid was preserved on blur event - #118

### DIFF
--- a/src/mask.js
+++ b/src/mask.js
@@ -410,8 +410,10 @@ angular.module('ui.mask', [])
                                         valueMasked = '';
                                         iElement.val('');
                                         scope.$apply(function() {
-                                            //don't call $setViewValue to avoid changing $pristine state.
-                                            controller.$viewValue = '';
+                                            //only $setViewValue when not $pristine to avoid changing $pristine state.
+                                            if (!controller.$pristine) {
+                                                controller.$setViewValue('');
+                                            }
                                         });
                                     }
                                 }

--- a/test/maskSpec.js
+++ b/test/maskSpec.js
@@ -676,6 +676,16 @@ describe("uiMask", function () {
       expect(input.val()).toBe("");
       expect(input.attr("placeholder")).toBe("PLACEHOLDER");
     });
+
+    it("should not preserve $invalid on blur event", function() {
+      var form  = compileElement(formHtml);
+      var input = form.find("input");
+      scope.$apply("x = ''");
+      scope.$apply("mask = '(A) * 9'");
+      input.val("a").triggerHandler("input");
+      input.triggerHandler("blur");
+      expect(scope.test.input.$invalid).toBe(false);
+    });
   });
 
   describe("Configuration Provider", function() {


### PR DESCRIPTION
Issue #118 

$setViewValue solved the issue. There was a comment saying 'don't call $setViewValue to avoid changing $pristine state.' so i just added a simple test to only call it when $pristine is false.