### PR TITLE
fix backspace event for android

### DIFF
--- a/src/mask.js
+++ b/src/mask.js
@@ -483,7 +483,7 @@ angular.module('ui.mask', [])
 
                             function keydownHandler(e) {
                                 /*jshint validthis: true */
-                                var isKeyBackspace = e.which === 8,
+                                var isKeyBackspace = e.which === 8 || e.which === 229,
                                     caretPos = getCaretPosition(this) - 1 || 0; //value in keydown is pre change so bump caret position back to simulate post change
 
                                 if (isKeyBackspace) {
@@ -534,7 +534,7 @@ angular.module('ui.mask', [])
 
                                         isKeyLeftArrow = eventWhich === 37,
                                         // Necessary due to "input" event not providing a key code
-                                        isKeyBackspace = eventWhich === 8 || (eventType !== 'keyup' && isDeletion && (caretPosDelta === -1)),
+                                        isKeyBackspace = eventWhich === 8 || eventWhich === 229 || (eventType !== 'keyup' && isDeletion && (caretPosDelta === -1)),
                                         isKeyDelete = eventWhich === 46 || (eventType !== 'keyup' && isDeletion && (caretPosDelta === 0) && !wasSelected),
                                         // Handles cases where caret is moved and placed in front of invalid maskCaretMap position. Logic below
                                         // ensures that, on click or leftward caret placement, caret is moved leftward until directly right of
@@ -550,6 +550,7 @@ angular.module('ui.mask', [])
                                 }
 
                                 if (isKeyBackspace && preventBackspace) {
+                                    preventBackspace = false;
                                     iElement.val(maskPlaceholder);
                                     // This shouldn't be needed but for some reason after aggressive backspacing the controller $viewValue is incorrect.
                                     // This keeps the $viewValue updated and correct.


### PR DESCRIPTION
http://stackoverflow.com/questions/25043934/is-it-ok-to-ignore-keydown-events-with-keycode-229/25509350

Input has placeholder and mask +0 999 999 99 99. On android device (nexus 7 android 6) if press backspace then catch event with key code 229, not 8.