### PR TITLE
Prefer window.getSelection over document.selection

### DIFF
--- a/src/mask.js
+++ b/src/mask.js
@@ -707,6 +707,9 @@ angular.module('ui.mask', [])
                                 if (input.selectionStart !== undefined) {
                                     return (input.selectionEnd - input.selectionStart);
                                 }
+                                if (window.getSelection) {
+                                    return (window.getSelection().toString().length);
+                                }
                                 if (document.selection) {
                                     return (document.selection.createRange().text.length);
                                 }


### PR DESCRIPTION
document.selection is non-standard, and window.getSelection is preferred.  I ran into a bug where when using ui-mask inside of an iframe in IE11, our users were getting the error "Unpositioned markup pointer for this operation".

Another example of this error: https://social.msdn.microsoft.com/Forums/sqlserver/en-US/56bb70c7-eaef-4abb-b506-d2a2d4726e9e/ie10-error-unpositioned-markup-pointer-for-this-operation?forum=iewebdevelopment