### PR TITLE
Add additional checking for angular source

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 //https://github.com/angular/angular.js/pull/10732
 
-var angular = require('angular');
+if (typeof angular !== 'undefined') {
+  var angular = require('angular');
+}
 var mask = require('./dist/mask');
 
 module.exports = 'ui.mask';


### PR DESCRIPTION
In my case I load `angular.js` from cdn before import of the module.
So main point is that you need to have additional checking to `require` the angular source.