### PR TITLE
improvement: support string mask pattern in maskDefinitions

### DIFF
--- a/src/mask.js
+++ b/src/mask.js
@@ -410,7 +410,12 @@ angular.module('ui.mask', [])
                                             maskCaretMap.push(characterCount);
 
                                             maskPlaceholder += getPlaceholderChar(i - numberOfOptionalCharacters);
-                                            maskPatterns.push(linkOptions.maskDefinitions[chr]);
+                                            if(angular.isString(linkOptions.maskDefinitions[chr])){
+                                                maskPatterns.push(new RegExp(linkOptions.maskDefinitions[chr]));
+                                            }
+                                            else{
+                                                maskPatterns.push(linkOptions.maskDefinitions[chr]);
+                                            }
 
                                             characterCount++;
                                             if (!isOptional) {

--- a/test/maskSpec.js
+++ b/test/maskSpec.js
@@ -393,6 +393,20 @@ describe("uiMask", function () {
       input.triggerHandler("change"); // Because IE8 and below are terrible
       expect(scope.x).toBeUndefined();
     });
+
+    it('should accept string patterns as well', function(){
+        scope.options = {
+            escChar: '!',
+            maskDefinitions: {
+                "a": '[a-z]'
+            }
+        };
+        var input  = compileElement(inputHtml);
+        scope.$apply("mask = 'a'");
+        input.val("cC").triggerHandler("input");
+        expect(input.val()).toBe("c");
+
+    })
   });
 
   describe("escChar", function () {


### PR DESCRIPTION
as `RegExp` json serialization is problematic, it's a good idea to let developer pass string representation of pattern regex.

So from now the following `maskDefinitions` both work:
```
maskDefinitions = {
    a: /[a-z]/
}
maskDefinitions = {
    a: '[a-z]'
}
 ```